### PR TITLE
Fixed primary key fields Graphql definition

### DIFF
--- a/src/core/Directus/GraphQL/FieldsConfig.php
+++ b/src/core/Directus/GraphQL/FieldsConfig.php
@@ -50,7 +50,7 @@ class FieldsConfig
                     $fields[$v['field']] = Types::directusFile();
                     break;
                 case 'integer':
-                    $fields[$v['field']] = ($v['interface'] == 'primary-key') ? $fields[$v['field']] = Types::id() : Types::int();
+                    $fields[$v['field']] = ($v['primary_key'] == true) ? $fields[$v['field']] = Types::id() : Types::int();
                     break;
                 case 'decimal':
                     $fields[$v['field']] = Types::float();


### PR DESCRIPTION
The check for primary key fields was wrong so they never are defined as ID. So the Int! definition raises a Graphql validation error on primary key fields:

`Interface field Node.id expects type ID but ###.id is type Int!.`